### PR TITLE
Pin connection_pool to ~> 2.5 to fix assets:precompile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,13 @@ gem "rails", "~> 8.1"
 gem "pg", "~> 1.6"
 gem "redis", ">= 4.0.1"
 
+# Pin connection_pool to 2.x - connection_pool 3.x has a breaking change
+# (keyword-only arguments) that is incompatible with Rails 8.1.1's
+# ActiveSupport::Cache::RedisCacheStore, causing assets:precompile to fail with
+# `ArgumentError: wrong number of arguments (given 1, expected 0)`.
+# See https://github.com/rails/rails/issues/56461
+gem "connection_pool", "~> 2.5"
+
 # Deployment
 gem "puma", ">= 5.0"
 gem "bootsnap", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -533,6 +533,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  connection_pool (~> 2.5)
   debug
   dotenv-rails
   erb_lint


### PR DESCRIPTION
Since `connection_pool` 3.0 introduced a breaking change making its initializer accept only keyword arguments. Rails 8.1.1's
ActiveSupport::Cache::RedisCacheStore still calls
`ConnectionPool.new(pool_options)` with a positional hash, which raises `ArgumentError: wrong number of arguments (given 1, expected 0)` during `Rails.application.initialize!`, breaking the Docker `assets:precompile` step.

Pin to the latest 2.x (which sidekiq 8.0.8 also supports) until Rails ships a released version containing the upstream fix (rails/rails#56292).

Refs: https://github.com/rails/rails/issues/56461

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated dependency version constraints to ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->