### PR TITLE
Add docs.sure.am to website navigation

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -31,6 +31,10 @@ module NavigationHelper
   def header_nav_resources_links
     [
       {
+        text: "Documentation",
+        path: "https://docs.sure.am"
+      },
+      {
         text: "Join Community",
         path: discord_url
       },
@@ -68,6 +72,10 @@ module NavigationHelper
 
   def footer_resources
     [
+      {
+        text: "Documentation",
+        path: "https://docs.sure.am"
+      },
       {
         text: "Join Community",
         path: discord_url


### PR DESCRIPTION
## Summary
- add a `Documentation` link to the Resources dropdown
- add the same docs link to the footer Resources section
- point both to <https://docs.sure.am> so the docs site is easier to discover

## Why
`docs.sure.am` exists, but it isn't currently surfaced from the marketing site chrome. This puts it in the main shared navigation seam without adding template-specific duplication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Documentation resource link accessible from the navigation header and footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->