### PR TITLE
Add docs link to website header

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -44,6 +44,7 @@
         <%= link_to "https://github.com/we-promise/sure", class: "text-xl leading-[150%] flex items-center justify-between text-base text-gray-700" do %>
           Contribute <%= lucide_icon("arrow-up-right", class: "w-6 h-6") %>
         <% end %>
+        <%= link_to "Docs", "https://docs.sure.am", class: "text-xl leading-[150%] text-gray-700" %>
       </div>
     </div>
   </nav>
@@ -98,6 +99,7 @@
       <%= link_to "https://app.sure.am/sessions/new", class: "p-2 pl-3 text-sm leading-[18px] text-white bg-gray-900 rounded-lg group hover:bg-gray-800 border-[1px] border-gray-900 flex items-center gap-1 shadow-btn-dark-inset-1 shadow-btn-dark-inset-2 shadow-btn-dark-inset-3 rainbow-button" do %>
         🚀 Try it <%= lucide_icon("chevron-right", alt: "Menu", class: "text-gray-500 group-hover:text-white transition-all duration-150 ease-in-out w-4 h-4") %>
       <% end %>
+      <%= link_to "Docs", "https://docs.sure.am", class: "py-2 px-3 text-sm leading-[18px] text-black group rounded-lg hover:bg-alpha-black-50 bg-transparent border-[1px] border-gray-300 hover:border-gray-300 flex items-center gap-1 shadow-btn-plain-inset-1 shadow-btn-plain-inset-2" %>
     </menu>
     <%= lucide_icon("menu", alt: "Menu", class: "w-6 h-6 md:hidden", 'data-action': 'click->navbar#toggleMobileMenu') %>
     <div class="flex flex-col hidden w-full mt-4 font-medium md:hidden" data-navbar-target="mobileMenu">
@@ -132,6 +134,7 @@
       </div>
         <%= link_to "Pricing", pricing_free_path, class: "text-base text-gray-700" %>
         <%= link_to "Contribute", "https://github.com/we-promise/sure", class: "text-base text-gray-700" %>
+        <%= link_to "Docs", "https://docs.sure.am", class: "text-base text-gray-700" %>
         <div class="flex flex-col gap-3 mt-4">
           <%= link_to "Sign in", "https://app.sure.am",
               class: "w-full py-2 px-3 text-sm text-center text-gray-900 rounded-lg border border-gray-300 hover:bg-gray-50" %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -134,7 +134,6 @@
       </div>
         <%= link_to "Pricing", pricing_free_path, class: "text-base text-gray-700" %>
         <%= link_to "Contribute", "https://github.com/we-promise/sure", class: "text-base text-gray-700" %>
-        <%= link_to "Docs", "https://docs.sure.am", class: "text-base text-gray-700" %>
         <div class="flex flex-col gap-3 mt-4">
           <%= link_to "Sign in", "https://app.sure.am",
               class: "w-full py-2 px-3 text-sm text-center text-gray-900 rounded-lg border border-gray-300 hover:bg-gray-50" %>


### PR DESCRIPTION
## Summary

- Add a Docs link pointing to `https://docs.sure.am` at the end of the website header navigation.
- Include the link in desktop and mobile navigation layouts.

## Validation

- `git diff --check` passes.
- ERB lint runs but reports five existing quote-style issues elsewhere in `_navbar.html.erb`; the new lines introduce no lint errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Docs” link to the navigation menu across desktop and mobile layouts, providing quick access to the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->