### PR TITLE
Add render.yaml Blueprint for deploying on Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We fully support AI-assisted development. As a team, we typically use [Cursor](h
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/we-promise/website)
 
-`render.yaml` at the repo root defines the whole stack: the web service, a Sidekiq worker, Postgres, and two Key Value instances. No API key values live in the repo. Create a `sure-secrets` environment group with your keys before you apply the Blueprint, and both services will read from it. Values in a group defined by a Blueprint get overwritten on every sync, so `render.yaml` references the group without defining it.
+`render.yaml` at the repo root defines the whole stack: the web service, a Sidekiq worker, Postgres, and two Key Value instances. No API key values live in the repo. Create a `sure-website-secrets` environment group with your keys before you apply the Blueprint, and both services will read from it. Values in a group defined by a Blueprint get overwritten on every sync, so `render.yaml` references the group without defining it.
 
 The group needs `SECRET_KEY_BASE`, which the Dashboard can generate for you. Every other key is optional and each integration skips itself when its key is unset. `render.yaml` lists them all in a comment.
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ We fully support AI-assisted development. As a team, we typically use [Cursor](h
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/we-promise/website)
 
-`render.yaml` at the repo root defines the whole stack: the web service, a Sidekiq worker, Postgres, and two Key Value instances. Applying the Blueprint creates everything, including an environment group named `sure-secrets`.
+`render.yaml` at the repo root defines the whole stack: the web service, a Sidekiq worker, Postgres, and two Key Value instances. No API key values live in the repo. Create a `sure-secrets` environment group with your keys before you apply the Blueprint, and both services will read from it. Values in a group defined by a Blueprint get overwritten on every sync, so `render.yaml` references the group without defining it.
 
-No API key values live in the repo. The group declares its keys with `sync: false`, which Render ignores inside an environment group, so the keys start out unset. Set them in the Dashboard under the `sure-secrets` group.
+The group needs `SECRET_KEY_BASE`, which the Dashboard can generate for you. Every other key is optional and each integration skips itself when its key is unset. `render.yaml` lists them all in a comment.
 
 ## Copyright & license
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ bin/dev
 
 We fully support AI-assisted development. As a team, we typically use [Cursor](https://cursor.com) for that. As such, we've included files with some rules for Cursor and Claude Code, along with prompts for certain tasks.
 
+## Deploy
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/we-promise/website)
+
+`render.yaml` at the repo root defines the whole stack: the web service, a Sidekiq worker, Postgres, and two Key Value instances. Applying the Blueprint creates everything, including an environment group named `sure-secrets`.
+
+No API key values live in the repo. The group declares its keys with `sync: false`, which Render ignores inside an environment group, so the keys start out unset. Set them in the Dashboard under the `sure-secrets` group.
+
 ## Copyright & license
 
 Sure is distributed under an [AGPLv3 license](https://github.com/we-promise/sure/blob/main/LICENSE). "Sure" and the "S" logo are pending trademarks of Sure Finances, LLC

--- a/render.yaml
+++ b/render.yaml
@@ -81,40 +81,14 @@ projects:
             region: oregon
             postgresMajorVersion: "17"
 
-        envVarGroups:
-          - name: sure-secrets
-            envVars:
-              - key: SECRET_KEY_BASE
-                generateValue: true
-              - key: CONVERTKIT_API_KEY
-                sync: false
-              - key: CONVERTKIT_API_SECRET
-                sync: false
-              - key: CONVERTKIT_FORM_ID
-                sync: false
-              - key: CONVERTKIT_TAG_ID
-                sync: false
-              - key: SYNTH_API_KEY
-                sync: false
-              - key: FRED_API_KEY
-                sync: false
-              - key: BANNERBEAR_API_KEY
-                sync: false
-              - key: PLAID_CLIENT_ID
-                sync: false
-              - key: PLAID_SECRET
-                sync: false
-              - key: PLAID_ENVIRONMENT
-                sync: false
-              - key: OPENAI_API_KEY
-                sync: false
-              - key: SEOBOT_API_KEY
-                sync: false
-              - key: SENTRY_DSN
-                sync: false
-              - key: POSTHOG_KEY
-                sync: false
-              - key: DISCORD_URL
-                sync: false
-              - key: SURE_ROADMAP_URL
-                sync: false
+# The sure-secrets environment group is intentionally not defined here.
+# A group defined in a Blueprint has its values overwritten on every sync, so
+# create it in the Dashboard before applying this Blueprint:
+#
+#   SECRET_KEY_BASE        (use the Dashboard's generate button)
+#   CONVERTKIT_API_KEY, CONVERTKIT_FORM_ID, CONVERTKIT_TAG_ID
+#   FRED_API_KEY
+#   PLAID_CLIENT_ID, PLAID_SECRET, PLAID_ENVIRONMENT
+#   OPENAI_API_KEY, SEOBOT_API_KEY
+#   SENTRY_DSN, POSTHOG_KEY
+#   DISCORD_URL, SURE_ROADMAP_URL

--- a/render.yaml
+++ b/render.yaml
@@ -32,7 +32,7 @@ projects:
                   name: sure-queue
                   type: keyvalue
                   property: connectionString
-              - fromGroup: sure-secrets
+              - fromGroup: sure-website-secrets
 
           - type: worker
             name: sure-worker
@@ -59,7 +59,7 @@ projects:
                   name: sure-queue
                   type: keyvalue
                   property: connectionString
-              - fromGroup: sure-secrets
+              - fromGroup: sure-website-secrets
 
           - type: keyvalue
             name: sure-cache
@@ -80,8 +80,9 @@ projects:
             plan: basic-256mb
             region: oregon
             postgresMajorVersion: "17"
+            ipAllowList: []
 
-# The sure-secrets environment group is intentionally not defined here.
+# The sure-website-secrets environment group is intentionally not defined here.
 # A group defined in a Blueprint has its values overwritten on every sync, so
 # create it in the Dashboard before applying this Blueprint:
 #

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,120 @@
+projects:
+  - name: sure
+    environments:
+      - name: production
+
+        services:
+          - type: web
+            name: sure-website
+            runtime: docker
+            plan: starter
+            region: oregon
+            dockerfilePath: ./Dockerfile
+            healthCheckPath: /up
+            preDeployCommand: ./bin/rails db:prepare
+            autoDeployTrigger: commit
+            envVars:
+              - key: RAILS_MAX_THREADS
+                value: "3"
+              - key: WEB_CONCURRENCY
+                value: "2"
+              - key: DATABASE_URL
+                fromDatabase:
+                  name: sure-db
+                  property: connectionString
+              - key: REDIS_CACHE_URL
+                fromService:
+                  name: sure-cache
+                  type: keyvalue
+                  property: connectionString
+              - key: REDIS_QUEUE_URL
+                fromService:
+                  name: sure-queue
+                  type: keyvalue
+                  property: connectionString
+              - fromGroup: sure-secrets
+
+          - type: worker
+            name: sure-worker
+            runtime: docker
+            plan: starter
+            region: oregon
+            dockerfilePath: ./Dockerfile
+            dockerCommand: bundle exec sidekiq
+            autoDeployTrigger: commit
+            envVars:
+              - key: RAILS_MAX_THREADS
+                value: "3"
+              - key: DATABASE_URL
+                fromDatabase:
+                  name: sure-db
+                  property: connectionString
+              - key: REDIS_CACHE_URL
+                fromService:
+                  name: sure-cache
+                  type: keyvalue
+                  property: connectionString
+              - key: REDIS_QUEUE_URL
+                fromService:
+                  name: sure-queue
+                  type: keyvalue
+                  property: connectionString
+              - fromGroup: sure-secrets
+
+          - type: keyvalue
+            name: sure-cache
+            plan: starter
+            region: oregon
+            maxmemoryPolicy: allkeys-lru
+            ipAllowList: []
+
+          - type: keyvalue
+            name: sure-queue
+            plan: starter
+            region: oregon
+            maxmemoryPolicy: noeviction
+            ipAllowList: []
+
+        databases:
+          - name: sure-db
+            plan: basic-256mb
+            region: oregon
+            postgresMajorVersion: "17"
+
+        envVarGroups:
+          - name: sure-secrets
+            envVars:
+              - key: SECRET_KEY_BASE
+                generateValue: true
+              - key: CONVERTKIT_API_KEY
+                sync: false
+              - key: CONVERTKIT_API_SECRET
+                sync: false
+              - key: CONVERTKIT_FORM_ID
+                sync: false
+              - key: CONVERTKIT_TAG_ID
+                sync: false
+              - key: SYNTH_API_KEY
+                sync: false
+              - key: FRED_API_KEY
+                sync: false
+              - key: BANNERBEAR_API_KEY
+                sync: false
+              - key: PLAID_CLIENT_ID
+                sync: false
+              - key: PLAID_SECRET
+                sync: false
+              - key: PLAID_ENVIRONMENT
+                sync: false
+              - key: OPENAI_API_KEY
+                sync: false
+              - key: SEOBOT_API_KEY
+                sync: false
+              - key: SENTRY_DSN
+                sync: false
+              - key: POSTHOG_KEY
+                sync: false
+              - key: DISCORD_URL
+                sync: false
+              - key: SURE_ROADMAP_URL
+                sync: false


### PR DESCRIPTION
Adds a `render.yaml` at the repo root so the site can be deployed on Render from a single Blueprint, plus a README section and a Deploy to Render button.

## What it creates

One project named `sure` with five resources:

| Resource | Type | Why |
| --- | --- | --- |
| `sure-website` | Web (Docker) | Puma, health check on `/up`, `db:prepare` as the pre-deploy command |
| `sure-worker` | Worker (Docker) | Sidekiq and the sidekiq-cron daily institution sync |
| `sure-db` | Postgres 17 | `DATABASE_URL` |
| `sure-cache` | Key Value | `REDIS_CACHE_URL`, `allkeys-lru` |
| `sure-queue` | Key Value | `REDIS_QUEUE_URL`, `noeviction` |

The cache and queue are separate because they need opposite eviction policies. Sidekiq loses jobs under `allkeys-lru`.

No source changes. The existing `Dockerfile`, `config/puma.rb`, and the `/up` route already work as they are, and Rails merges `DATABASE_URL` over the hardcoded `production` block in `config/database.yml`.

## Secrets

`SECRET_KEY_BASE` is generated once in a `sure-secrets` env group so the web service and the worker share it. Declaring `generateValue: true` on each service separately would produce two different keys and break signed cookies.

The other 16 keys are declared with `sync: false` and no values, so nothing sensitive is in the repo. Render ignores `sync: false` inside an env group, which means the keys start out unset and have to be filled in from the Dashboard or the API after the first apply. Every integration checks its own key and skips itself when the value is blank, so the site boots with none of them set.

## Testing this branch

The button in the README points at `main`, which has no `render.yaml` until this merges. To try the flow before then, use a branch-specific link:

https://render.com/deploy?repo=https://github.com/Ho1yShif/website&branch=render-blueprint

I applied that on a test workspace. Both services came up, `db:prepare` loaded the seeds, and `/`, `/tools`, `/articles`, `/bank-search`, and `/roadmap` all return 200.

## Notes for review

- `SYNTH_API_KEY` is in the group but unusable. `synthfinance.com` now redirects to a domain-sale listing and `api.synthfinance.com` has no DNS record. The three tools that depend on it are already blocked by the hidden list in `ToolsController`, so nothing 500s.
- `bin/docker-entrypoint` also runs `db:prepare` when the command is `./bin/rails server`, so migrations run twice on a web deploy. `db:prepare` is safe to repeat.
- No persistent disk. Active Storage is set to `:local` but no model declares an attachment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Render Blueprint support for deploying the application’s web service, background worker, PostgreSQL database, cache, and queue.
  - Configured health checks, database preparation, automatic deployments, and service connections.
  - Restricted external access to the managed database.
  - Added separate cache and queue services with tailored eviction policies.

- **Documentation**
  - Added deployment documentation covering required secret configuration through the Render Dashboard.
  - Updated the documented environment group name to `sure-website-secrets`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->